### PR TITLE
Raise errors as exceptions

### DIFF
--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -40,7 +40,7 @@ class Client(object):
             if response.status_code in (401, 403):
                 exc_cls = (
                     exc.AuthAlligatorUnauthorizedError
-                )  # type: Type[exc.AuthAlligatorException]
+                )  # type: Type[exc.UnexpectedStatusCode]
             else:
                 exc_cls = exc.UnexpectedStatusCode
 

--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from typing import Any, Dict, Type, TypeVar, Union
+from typing import Any, Dict, Type, TypeVar
 
 import attr
 import requests
@@ -29,7 +29,7 @@ class Client(object):
     ):
         # type: (...) -> T
         response = requests.post(
-            f"{self.service_url}/graphql",
+            "{}/graphql".format(self.service_url),
             json={"query": query, "variables": variables},
             auth=(self.token, ""),
             timeout=self.timeout,
@@ -37,9 +37,10 @@ class Client(object):
 
         # responses (even for errors) should always be HTTP 200
         if response.status_code != 200:
-            exc_cls: Type[exc.AuthAlligatorException]
             if response.status_code in (401, 403):
-                exc_cls = exc.AuthAlligatorUnauthorizedError
+                exc_cls = (
+                    exc.AuthAlligatorUnauthorizedError
+                )  # type: Type[exc.AuthAlligatorException]
             else:
                 exc_cls = exc.UnexpectedStatusCode
 
@@ -61,7 +62,7 @@ class Client(object):
         authorization_code,  # type: str
         redirect_uri,  # type: str
     ):
-        # type: (...) -> Union[entities.AuthorizeAccountPayload, entities.AccountError]
+        # type: (...) -> entities.AuthorizeAccountPayload
         """Obtain OAuth access token and refresh token.
 
         This does some basic error handling on the reponse.
@@ -111,6 +112,13 @@ class Client(object):
             return_types=entities.Mutation,
         )
         assert result.authorize_account is not entities.OMITTED
+        if isinstance(result.authorize_account, entities.AccountError):
+            raise exc.AccountError(
+                code=result.authorize_account.code,
+                message=result.authorize_account.message,
+                retry_in=result.authorize_account.retry_in,
+            )
+
         return result.authorize_account
 
     def query_account(
@@ -119,7 +127,7 @@ class Client(object):
         username,  # type: str
         account_key,  # type: str
     ):
-        # type: (...) -> Union[entities.Account, entities.AccountError]
+        # type: (...) -> entities.Account
         """Obtain a valid access token.
 
         Args:
@@ -162,4 +170,10 @@ class Client(object):
             return_types=entities.Query,
         )
         assert result.account is not entities.OMITTED
+        if isinstance(result.account, entities.AccountError):
+            raise exc.AccountError(
+                code=result.account.code,
+                message=result.account.message,
+                retry_in=result.account.retry_id,
+            )
         return result.account

--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -174,6 +174,6 @@ class Client(object):
             raise exc.AccountError(
                 code=result.account.code,
                 message=result.account.message,
-                retry_in=result.account.retry_id,
+                retry_in=result.account.retry_in,
             )
         return result.account

--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -147,7 +147,7 @@ class AccountError(BaseAAEntity):
     code = attr.attrib(
         converter=enum_converter(enums.AccountErrorCode),  # type: ignore[misc]
     )  # type: enums.AccountErrorCode
-    message = attr.attrib()  # type: Optional[int]
+    message = attr.attrib()  # type: Optional[str]
     retry_in = attr.attrib()  # type: Optional[int]
 
 

--- a/authalligator_client/exceptions.py
+++ b/authalligator_client/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from . import enums
 

--- a/authalligator_client/exceptions.py
+++ b/authalligator_client/exceptions.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Optional
+
+from . import enums
 
 
 class AuthAlligatorException(Exception):
@@ -12,7 +14,7 @@ class UnexpectedStatusCode(AuthAlligatorException):
         # type: (int, Union[str, bytes], *Any) -> None
         self.status_code = status_code
         self.content = content
-        super().__init__(*args)
+        super(UnexpectedStatusCode, self).__init__(*args)
 
 
 class AuthAlligatorQueryError(AuthAlligatorException):
@@ -26,3 +28,22 @@ class AuthAlligatorQueryError(AuthAlligatorException):
 
 class AuthAlligatorUnauthorizedError(UnexpectedStatusCode):
     """Raised specifically for 401 and 403 status codes."""
+
+    pass
+
+
+class ExecutionResultError(AuthAlligatorException):
+    """Raised for the "expected" class of errors, on the schema."""
+
+    pass
+
+
+class AccountError(ExecutionResultError):
+    """Corresponds with the AccountError entity type."""
+
+    def __init__(self, code, message, retry_in, *args):
+        # type: (enums.AccountErrorCode, Optional[Union[str, bytes]], Optional[int], *Any) -> None
+        self.code = code
+        self.message = message
+        self.retry_in = retry_in
+        super(AccountError, self).__init__(*args)

--- a/authalligator_client/input_types.py
+++ b/authalligator_client/input_types.py
@@ -4,27 +4,27 @@ from . import enums
 from .utils import as_json_dict, enum_converter, to_camel_case
 
 
-@attr.attrs(auto_attribs=True)
-class AuthAlligatorInputType:
+@attr.attrs()
+class AuthAlligatorInputType(object):
     def as_dict(self):
         serialized = as_json_dict(self)
         # snake_case to camelCase
         return {to_camel_case(k): v for k, v in serialized.items()}
 
 
-@attr.attrs(auto_attribs=True)
+@attr.attrs()
 class AuthorizeAccountInput(AuthAlligatorInputType):
-    provider: enums.ProviderType = attr.attrib(
+    provider = attr.attrib(
         converter=enum_converter(enums.ProviderType)  # type: ignore[misc]
-    )
-    authorization_code: str
-    redirect_uri: str
+    )  # type: enums.ProviderType
+    authorization_code = attr.attrib()  # type: str
+    redirect_uri = attr.attrib()  # type: str
 
 
-@attr.attrs(auto_attribs=True)
+@attr.attrs()
 class AccountAccessInput(AuthAlligatorInputType):
-    provider: enums.ProviderType = attr.attrib(
+    provider = attr.attrib(
         converter=enum_converter(enums.ProviderType)  # type: ignore[misc]
-    )
-    username: str
-    account_key: str
+    )  # type: enums.ProviderType
+    username = attr.attrib()  # type: str
+    account_key = attr.attrib()  # type: str

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = ["attrs", "requests", "structlog", "typing", "ciso8601"]
 if sys.version_info < (3, 3):
     install_requires += ["enum34"]
 
-tests_require = install_requires + ["pytest", "flake8"]
+tests_require = install_requires + ["pytest", "flake8", "mock<4"]
 
 setup(
     name="authalligator_client",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,94 @@
+import datetime
+import contextlib
+import pytest
+import mock
+
+from authalligator_client.client import Client
+from authalligator_client.enums import ProviderType, AccountErrorCode
+from authalligator_client.entities import AuthorizeAccountPayload, Account
+from authalligator_client import exceptions as exc
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
+@contextlib.contextmanager
+def mock_gql_response(json_data, status_code=200):
+    """Shortcut for mocking a reponse."""
+    with mock.patch("authalligator_client.client.requests.post") as mock_post:
+        mock_post.return_value = MockResponse(
+            json_data=json_data, status_code=status_code
+        )
+        yield mock_post
+
+
+@pytest.fixture
+def client():
+    return Client(token="dummy", service_url="example.com")
+
+
+def test_authorize_account(client):
+    expires_at = datetime.datetime.now()
+    gql_response = {
+        "data": {
+            "authorizeAccount": {
+                "__typename": "AuthorizeAccountPayload",
+                "account": {
+                    "provider": "TEST",
+                    "username": "test-username",
+                    "accessToken": "access-token-example",
+                    "accessTokenExpiresAt": expires_at.isoformat(),
+                },
+                "accountKey": "dummy-account-key",
+                "numberOfAccountKeys": 1,
+            }
+        }
+    }
+    with mock_gql_response(gql_response):
+        authorize_account = client.authorize_account(
+            provider=ProviderType.TEST,
+            authorization_code="example-auth-code",
+            redirect_uri="example.com/oauth/redirect",
+        )
+
+    assert isinstance(authorize_account, AuthorizeAccountPayload)
+    assert authorize_account.account_key == "dummy-account-key"
+    assert authorize_account.number_of_account_keys == 1
+
+    account = authorize_account.account
+    assert isinstance(account, Account)
+    assert account.provider == ProviderType.TEST
+    assert account.username == "test-username"
+    assert account.access_token == "access-token-example"
+    assert account.access_token_expires_at == expires_at
+
+
+def test_authorize_account_errors(client):
+    gql_response = {
+        "data": {
+            "authorizeAccount": {
+                "__typename": "AccountError",
+                "code": "TRY_LATER",
+                "message": "dummy-message",
+                "retryIn": 100,
+            }
+        }
+    }
+    with mock_gql_response(gql_response):
+        with pytest.raises(exc.AccountError) as exc_info:
+            client.authorize_account(
+                provider=ProviderType.TEST,
+                authorization_code="example-auth-code",
+                redirect_uri="example.com/oauth/redirect",
+            )
+
+    account_error = exc_info.value
+    assert account_error.code == AccountErrorCode.TRY_LATER
+    assert account_error.message == "dummy-message"
+    assert account_error.retry_in == 100

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,3 +92,55 @@ def test_authorize_account_errors(client):
     assert account_error.code == AccountErrorCode.TRY_LATER
     assert account_error.message == "dummy-message"
     assert account_error.retry_in == 100
+
+
+def test_query_account(client):
+    expires_at = datetime.datetime.now()
+    gql_response = {
+        "data": {
+            "account": {
+                "__typename": "Account",
+                "provider": "TEST",
+                "username": "test-username",
+                "accessToken": "access-token-example",
+                "accessTokenExpiresAt": expires_at.isoformat(),
+            }
+        }
+    }
+    with mock_gql_response(gql_response):
+        account = client.query_account(
+            provider=ProviderType.TEST,
+            username="test-username",
+            account_key="example-access-key",
+        )
+
+    assert isinstance(account, Account)
+    assert account.provider == ProviderType.TEST
+    assert account.username == "test-username"
+    assert account.access_token == "access-token-example"
+    assert account.access_token_expires_at == expires_at
+
+
+def test_query_account_errors(client):
+    gql_response = {
+        "data": {
+            "account": {
+                "__typename": "AccountError",
+                "code": "TRY_LATER",
+                "message": "dummy-message",
+                "retryIn": 100,
+            }
+        }
+    }
+    with mock_gql_response(gql_response):
+        with pytest.raises(exc.AccountError) as exc_info:
+            client.query_account(
+                provider=ProviderType.TEST,
+                username="test-username",
+                account_key="example-access-key",
+            )
+
+    account_error = exc_info.value
+    assert account_error.code == AccountErrorCode.TRY_LATER
+    assert account_error.message == "dummy-message"
+    assert account_error.retry_in == 100

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,13 @@
-import datetime
 import contextlib
-import pytest
-import mock
+import datetime
 
-from authalligator_client.client import Client
-from authalligator_client.enums import ProviderType, AccountErrorCode
-from authalligator_client.entities import AuthorizeAccountPayload, Account
+import mock
+import pytest
+
 from authalligator_client import exceptions as exc
+from authalligator_client.client import Client
+from authalligator_client.entities import Account, AuthorizeAccountPayload
+from authalligator_client.enums import AccountErrorCode, ProviderType
 
 
 class MockResponse:


### PR DESCRIPTION
This change does a couple things:
* raise account errors as exceptions
* add tests for the client
* backport more type annotations and python3-specific code
* fix a few minor bugs, mostly typos