### PR TITLE
Refactor README example to catch AccountErrors as exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,35 +6,34 @@ A python client for the AuthAlligator OAuth token management service.
 ```python
 from authalligator_client.client import Client
 from authalligator_client.enums import ProviderType
-from authalligator_client.entities import AccountError
+from authalligator_client.exceptions import AccountError
 
 client = Client(token='my-secret-token', service_url='authalligator.example.com')
 
-authorize_result = client.authorize_account(
-    provider=ProviderType.MICROSOFT,
-    authorization_code='my-code',
-    redirect_uri='mysite.example.com/oauth2/microsoft/callback',
-)
-if isinstance(authorize_result, AccountError):
-    print("encountered an error!", authorize_result.code, authorize_result.message)
-else:
+try:
+    authorize_result = client.authorize_account(
+        provider=ProviderType.MICROSOFT,
+        authorization_code='my-code',
+        redirect_uri='mysite.example.com/oauth2/microsoft/callback',
+    )
     print("Got an access token + key for refreshing!")
     print("Access Key:", authorize_result.access_key)
     print("Username:", authorize_result.account.username)
     print("Provider:", authorize_result.account.provider)
     print("Access Token:", authorize_result.account.access_token)
     print("Access Token Expiry:", authorize_result.account.access_token_expires_at)
+except AccountError as e:
+    print("encountered an error!", e.code, e.message)
 
-account_result = client.query_account(
-    provider=authorize_result.account.provider,
-    username=authorize_result.account.username,
-    account_key=authorize_result.account_key,
-)
-if isinstance(account_result, AccountError):
-    print("Encountered an error!", account_result.code, account_result.message)
-else:
+try:
+    account_result = client.query_account(
+        provider=authorize_result.account.provider,
+        username=authorize_result.account.username,
+        account_key=authorize_result.account_key,
+    )
     print("New Access Token:". account_result.access_token)
-
+except AccountError as e:
+    print("Encountered an error!", e.code, e.message)
 ```
 
 ## Running Tests


### PR DESCRIPTION
I must have missed this when refactoring the client to raise an exception instead of returning the other entity.