### PR TITLE
Drop typing requirement on py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,13 @@ from setuptools import setup
 with open("README.md", encoding="utf-8") as file:
     long_description = file.read()
 
-install_requires = ["attrs", "requests", "structlog", "typing", "ciso8601"]
+install_requires = [
+    "attrs",
+    "requests",
+    "structlog",
+    'typing;python_version<"3.5"',
+    "ciso8601",
+]
 
 if sys.version_info < (3, 3):
     install_requires += ["enum34"]


### PR DESCRIPTION
Per the docs, typing should only be installed for 3.5 and below. We only support 2.7, and 3.6+.