### PR TITLE
Add deleteOtherAccountKeys operation to client

### DIFF
--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -201,8 +201,10 @@ class Client(object):
                 have access to the specific account
 
         Returns:
-            Not much of anything, just a placeholder boolean. Raises an
-            exception for account errors.
+            DeleteOtherAccountKeysPayload on success.
+
+        Raises:
+            AccountError in case of an account error.
         """
         query = """
             mutation deleteOtherAccountKeys($input: AccountAccessInput!) {

--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -208,9 +208,6 @@ class Client(object):
             mutation deleteOtherAccountKeys($input: AccountAccessInput!) {
               deleteOtherAccountKeys(input: $input) {
                 __typename
-                ... on DeleteOtherAccountKeysPayload {
-                  _
-                }
                 ... on AccountError {
                   code
                   message

--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -169,22 +169,9 @@ class Account(BaseAAEntity):
 class DeleteOtherAccountKeysPayload(BaseAAEntity):
     TYPENAME = "DeleteOtherAccountKeysPayload"
 
-    # the real name of this should be "_", but attrs doesn't like that
-    val = attr.attrib()  # type: Optional[bool]
-
-    @classmethod
-    def from_api_response(cls, data):
-        # attrs doesn't like the real name of '_'
-        new_data = data.copy()
-        new_data["val"] = new_data.pop("_")
-        return super(DeleteOtherAccountKeysPayload, cls).from_api_response(new_data)
-
-    def as_dict(self):
-        data = super(DeleteOtherAccountKeysPayload, self).as_dict()
-        # attrs doesn't like the real name of '_'
-        data["_"] = data.pop("val")
-        return data
-
+    # While there's technically a "_" field in the schema, it's only a
+    # placeholder to work around the language not supporting empty responses.
+    # It has no meaning and will never have a meaningful value.
 
 @attr.attrs(frozen=True)
 class AuthorizeAccountPayload(BaseAAEntity):

--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -173,6 +173,7 @@ class DeleteOtherAccountKeysPayload(BaseAAEntity):
     # placeholder to work around the language not supporting empty responses.
     # It has no meaning and will never have a meaningful value.
 
+
 @attr.attrs(frozen=True)
 class AuthorizeAccountPayload(BaseAAEntity):
     TYPENAME = "AuthorizeAccountPayload"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -157,7 +157,6 @@ class TestDeleteOtherAccountKeys:
             "data": {
                 "deleteOtherAccountKeys": {
                     "__typename": "DeleteOtherAccountKeysPayload",
-                    "_": True,
                 }
             }
         }
@@ -169,7 +168,6 @@ class TestDeleteOtherAccountKeys:
             )
 
         assert isinstance(result, DeleteOtherAccountKeysPayload)
-        assert result.val is True
 
     def test_delete_other_account_keys_errors(self, client):
         gql_response = {


### PR DESCRIPTION
The primary change here is adding `delete_other_account_keys`, which performs the `deleteOtherAccountKeys` mutation. Also included in this change are:
* slightly refactor the entity converter
* add `DeleteOtherAccountKeysPayload` entity
* add `delete_other_account_keys` client test
* group client tests into classes
* drop the `MaybeOmitted` alias in favor of the explicit Union (it wasn't
  used enough to warrant the indirection)

I have tested the mutation (by copy/pasting the body) locally, which worked as expected. I haven't done an integration test, though setting that up here is on my TODO.