### PR TITLE
Add remaining mutations

### DIFF
--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -302,3 +302,59 @@ class Client(object):
                 retry_in=verify_account.retry_in,
             )
         return verify_account
+
+    def delete_account_key(
+        self,
+        provider,  # type: enums.ProviderType
+        username,  # type: str
+        account_key,  # type: str
+    ):
+        # type: (...) -> entities.DeleteAccountKeyPayload
+        """Delete this account key (but not others, if they exist).
+
+        Args:
+            provider: the AuthAlligator provider this account is for. (should
+                be one of the ``ProviderType`` enum values)
+            username: the AuthAlligator-provided username for the account (this
+                will likely _not_ be the human-legible email/username)
+            account_key: the AuthAlligator-specific secret key that proves we
+                have access to the specific account
+
+        Returns:
+            DeleteAccountKeyPayload on success.
+
+        Raises:
+            AccountError in case of an account error.
+        """
+        query = """
+            mutation deleteAccountKey($input: AccountAccessInput!) {
+              deleteAccountKey(input: $input) {
+                __typename
+                ... on AccountError {
+                  code
+                  message
+                  retryIn
+                }
+              }
+            }
+        """
+        input_var = input_types.AccountAccessInput(
+            provider=provider,
+            username=username,
+            account_key=account_key,
+        )
+        result = self._make_request(
+            query=query,
+            variables={"input": input_var.as_dict()},
+            return_types=entities.Mutation,
+        )
+
+        delete_key = result.delete_account_key
+        assert delete_key is not entities.OMITTED
+        if isinstance(delete_key, entities.AccountError):
+            raise exc.AccountError(
+                code=delete_key.code,
+                message=delete_key.message,
+                retry_in=delete_key.retry_in,
+            )
+        return delete_key

--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -358,3 +358,55 @@ class Client(object):
                 retry_in=delete_key.retry_in,
             )
         return delete_key
+
+    def delete_account(
+        self,
+        provider,  # type: enums.ProviderType
+        username,  # type: str
+    ):
+        # type: (...) -> entities.DeleteAccountPayload
+        """Delete this account (and all associated account keys).
+
+        Args:
+            provider: the AuthAlligator provider this account is for. (should
+                be one of the ``ProviderType`` enum values)
+            username: the AuthAlligator-provided username for the account (this
+                will likely _not_ be the human-legible email/username)
+
+        Returns:
+            DeleteAccountPayload on success.
+
+        Raises:
+            AccountError in case of an account error.
+        """
+        query = """
+            mutation deleteAccount($input: DeleteAccountInput!) {
+              deleteAccount(input: $input) {
+                __typename
+                ... on AccountError {
+                  code
+                  message
+                  retryIn
+                }
+              }
+            }
+        """
+        input_var = input_types.DeleteAccountInput(
+            provider=provider,
+            username=username,
+        )
+        result = self._make_request(
+            query=query,
+            variables={"input": input_var.as_dict()},
+            return_types=entities.Mutation,
+        )
+
+        delete_account = result.delete_account
+        assert delete_account is not entities.OMITTED
+        if isinstance(delete_account, entities.AccountError):
+            raise exc.AccountError(
+                code=delete_account.code,
+                message=delete_account.message,
+                retry_in=delete_account.retry_in,
+            )
+        return delete_account

--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -166,12 +166,29 @@ class Account(BaseAAEntity):
 
 
 @attr.attrs(frozen=True)
-class DeleteOtherAccountKeysPayload(BaseAAEntity):
+class DeleteOperation(BaseAAEntity):
+    """Base class for delete operation payloads.
+
+    These payloads don't actually have any field information in them. While
+    there's technically a "_" field in the schema, it's only a placeholder to
+    work around the language not supporting empty responses. It has no meaning
+    and will never have a meaningful value.
+
+    This class has no specific equivalent type, it's just a convenience type
+    for these entities.
+    """
+
+    pass
+
+
+@attr.attrs(frozen=True)
+class DeleteOtherAccountKeysPayload(DeleteOperation):
     TYPENAME = "DeleteOtherAccountKeysPayload"
 
-    # While there's technically a "_" field in the schema, it's only a
-    # placeholder to work around the language not supporting empty responses.
-    # It has no meaning and will never have a meaningful value.
+
+@attr.attrs(frozen=True)
+class DeleteAccountKeyPayload(DeleteOperation):
+    TYPENAME = "DeleteAccountKeyPayload"
 
 
 @attr.attrs(frozen=True)
@@ -214,6 +231,20 @@ class Mutation(BaseAAEntity):
             entity_converter([AuthorizeAccountPayload, AccountError]),
         ),
     )  # type: Union[Omitted, AuthorizeAccountPayload, AccountError]
+    verify_account = attr.attrib(  # type: ignore
+        default=OMITTED,
+        converter=cast(  # type: ignore[misc]
+            Union[Omitted, VerifyAccountPayload, AccountError],
+            entity_converter([VerifyAccountPayload, AccountError]),
+        ),
+    )  # type: Union[Omitted, VerifyAccountPayload, AccountError]
+    delete_account_key = attr.attrib(  # type: ignore
+        default=OMITTED,
+        converter=cast(  # type: ignore[misc]
+            Union[Omitted, DeleteAccountKeyPayload, AccountError],
+            entity_converter([DeleteAccountKeyPayload, AccountError]),
+        ),
+    )  # type: Union[Omitted, DeleteAccountKeyPayload, AccountError]
     delete_other_account_keys = attr.attrib(  # type: ignore
         default=OMITTED,
         # ignore unsupport converter warning
@@ -222,10 +253,3 @@ class Mutation(BaseAAEntity):
             entity_converter([DeleteOtherAccountKeysPayload, AccountError]),
         ),
     )  # type: Union[Omitted, DeleteOtherAccountKeysPayload, AccountError]
-    verify_account = attr.attrib(  # type: ignore
-        default=OMITTED,
-        converter=cast(  # type: ignore[misc]
-            Union[Omitted, VerifyAccountPayload, AccountError],
-            entity_converter([VerifyAccountPayload, AccountError]),
-        ),
-    )  # type: Union[Omitted, VerifyAccountPayload, AccountError]

--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -192,6 +192,11 @@ class DeleteAccountKeyPayload(DeleteOperation):
 
 
 @attr.attrs(frozen=True)
+class DeleteAccountPayload(DeleteOperation):
+    TYPENAME = "DeleteAccountPayload"
+
+
+@attr.attrs(frozen=True)
 class AuthorizeAccountPayload(BaseAAEntity):
     TYPENAME = "AuthorizeAccountPayload"
 
@@ -238,6 +243,13 @@ class Mutation(BaseAAEntity):
             entity_converter([VerifyAccountPayload, AccountError]),
         ),
     )  # type: Union[Omitted, VerifyAccountPayload, AccountError]
+    delete_account = attr.attrib(  # type: ignore
+        default=OMITTED,
+        converter=cast(  # type: ignore[misc]
+            Union[Omitted, DeleteAccountPayload, AccountError],
+            entity_converter([DeleteAccountPayload, AccountError]),
+        ),
+    )  # type: Union[Omitted, DeleteAccountPayload, AccountError]
     delete_account_key = attr.attrib(  # type: ignore
         default=OMITTED,
         converter=cast(  # type: ignore[misc]

--- a/authalligator_client/input_types.py
+++ b/authalligator_client/input_types.py
@@ -28,3 +28,11 @@ class AccountAccessInput(AuthAlligatorInputType):
     )  # type: enums.ProviderType
     username = attr.attrib()  # type: str
     account_key = attr.attrib()  # type: str
+
+
+@attr.attrs()
+class DeleteAccountInput(AuthAlligatorInputType):
+    provider = attr.attrib(
+        converter=enum_converter(enums.ProviderType)  # type: ignore[misc]
+    )  # type: enums.ProviderType
+    username = attr.attrib()  # type: str


### PR DESCRIPTION
* add `Client.delete_account_key`
* add `Client.delete_account`
* refactor delete operations to use a shared base payload entity