### PR TITLE
Drop the enum converter function, turns out it's not needed

### DIFF
--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -8,7 +8,7 @@ import structlog
 from attr import converters
 
 from . import enums
-from .utils import as_json_dict, enum_converter, to_snake_case
+from .utils import as_json_dict, to_snake_case
 
 logger = structlog.get_logger()
 
@@ -144,9 +144,7 @@ class BaseAAEntity(object):
 class AccountError(BaseAAEntity):
     TYPENAME = "AccountError"
 
-    code = attr.attrib(
-        converter=enum_converter(enums.AccountErrorCode),  # type: ignore[misc]
-    )  # type: enums.AccountErrorCode
+    code = attr.attrib(converter=enums.AccountErrorCode)  # type: enums.AccountErrorCode
     message = attr.attrib()  # type: Optional[str]
     retry_in = attr.attrib()  # type: Optional[int]
 
@@ -155,9 +153,7 @@ class AccountError(BaseAAEntity):
 class Account(BaseAAEntity):
     TYPENAME = "Account"
 
-    provider = attr.attrib(
-        converter=enum_converter(enums.ProviderType),  # type: ignore[misc]
-    )  # type: enums.ProviderType
+    provider = attr.attrib(converter=enums.ProviderType)  # type: enums.ProviderType
     username = attr.attrib()  # type: str
     access_token = attr.attrib()  # type: Optional[str]
     access_token_expires_at = attr.attrib(

--- a/authalligator_client/input_types.py
+++ b/authalligator_client/input_types.py
@@ -1,7 +1,7 @@
 import attr
 
 from . import enums
-from .utils import as_json_dict, enum_converter, to_camel_case
+from .utils import as_json_dict, to_camel_case
 
 
 @attr.attrs()
@@ -14,25 +14,19 @@ class AuthAlligatorInputType(object):
 
 @attr.attrs()
 class AuthorizeAccountInput(AuthAlligatorInputType):
-    provider = attr.attrib(
-        converter=enum_converter(enums.ProviderType)  # type: ignore[misc]
-    )  # type: enums.ProviderType
+    provider = attr.attrib(converter=enums.ProviderType)  # type: enums.ProviderType
     authorization_code = attr.attrib()  # type: str
     redirect_uri = attr.attrib()  # type: str
 
 
 @attr.attrs()
 class AccountAccessInput(AuthAlligatorInputType):
-    provider = attr.attrib(
-        converter=enum_converter(enums.ProviderType)  # type: ignore[misc]
-    )  # type: enums.ProviderType
+    provider = attr.attrib(converter=enums.ProviderType)  # type: enums.ProviderType
     username = attr.attrib()  # type: str
     account_key = attr.attrib()  # type: str
 
 
 @attr.attrs()
 class DeleteAccountInput(AuthAlligatorInputType):
-    provider = attr.attrib(
-        converter=enum_converter(enums.ProviderType)  # type: ignore[misc]
-    )  # type: enums.ProviderType
+    provider = attr.attrib(converter=enums.ProviderType)  # type: enums.ProviderType
     username = attr.attrib()  # type: str

--- a/authalligator_client/utils.py
+++ b/authalligator_client/utils.py
@@ -35,42 +35,6 @@ def to_snake_case(name):
     return _to_snake_case_regex_2.sub(r"\1_\2", s1).lower()
 
 
-def enum_converter(enum_type):
-    # type: (Type[enum.Enum]) -> Callable[[Union[str, enum.Enum]], enum.Enum]
-    """
-    Convert values to an instance of ``enum_type`` or raise ``ValueError``.
-
-    Example Usage::
-
-        class MyEnum(Enum):
-            a = 'a'
-            b = 'b'
-
-        @attrs(frozen=True)
-        class MyClass(object):
-            val = attrib(converter=enum_converter(MyEnum))
-
-        assert MyClass(val='a') == MyClass(val=MyEnum.a)
-    """
-
-    def _enum_converter(val):
-        # type: (Union[str, enum.Enum]) -> enum.Enum
-        if isinstance(val, enum_type):
-            return val
-
-        values = {e.value: e for e in enum_type}
-        if val not in values:
-            raise ValueError(
-                (
-                    "Enum value {} not found on enum type {}.\n" "Valid choices: {}"
-                ).format(val, enum_type, list(enum_type))
-            )
-
-        return values[val]
-
-    return _enum_converter
-
-
 def as_json_dict(obj):
     # type: (Any) -> Dict
     """

--- a/authalligator_client/utils.py
+++ b/authalligator_client/utils.py
@@ -1,7 +1,7 @@
 import datetime
 import enum
 import re
-from typing import Any, Callable, Dict, Type, Union
+from typing import Any, Dict
 
 import attr
 


### PR DESCRIPTION
As similar change was recently made in another one of our repositories. It turns out that the enum converter isn't needed at all when we're using proper `Enum`'s.