### PR TITLE
Add automatic retries on network requests

### DIFF
--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -7,6 +7,7 @@ import requests
 import structlog
 
 from . import entities, enums, exceptions as exc, input_types
+from .utils import retry
 
 logger = structlog.get_logger()
 
@@ -21,6 +22,7 @@ class Client(object):
 
     timeout = attr.attrib(default=10)  # type: int
 
+    @retry(exc=requests.exceptions.RequestException, tries=3, wait=1)
     def _make_request(
         self,
         query,  # type: str

--- a/authalligator_client/utils.py
+++ b/authalligator_client/utils.py
@@ -114,6 +114,7 @@ def retry(exc=Exception, tries=1, wait=0):
                     if tries_left <= 0:
                         raise
                     time.sleep(wait)
+
         return _retry
 
     return decorator

--- a/authalligator_client/utils.py
+++ b/authalligator_client/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import enum
 import re
+import time
 from typing import Any, Dict
 
 import attr
@@ -86,3 +87,33 @@ def as_json_dict(obj):
                 ret[k] = as_json_dict(v)
 
     return ret
+
+
+def retry(exc=Exception, tries=1, wait=0):
+    """
+    A way to retry a function call up to [tries] times if it throws
+    a [exc] exception, with [wait] seconds in between.
+
+    Can be used as a decorator factory.
+
+    Example Usage:
+        @retry(exc=ValueError, tries=10, wait=0.3)
+        def unreliable_function(foo):
+            # ...
+        unreliable_function('boy')
+    """
+
+    def decorator(func):
+        def _retry(*args, **kwargs):
+            tries_left = tries
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except exc:
+                    tries_left -= 1
+                    if tries_left <= 0:
+                        raise
+                    time.sleep(wait)
+        return _retry
+
+    return decorator

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,14 +46,15 @@ class TestClientRetries:
     @mock.patch("authalligator_client.utils.time.sleep")
     def test_basic(self, client):
         with mock.patch("authalligator_client.client.requests.post") as mock_post:
-            a = 0
 
             def third_time_is_the_charm(*args, **kwargs):
-                nonlocal a
-                if a < 2:
-                    a += 1
+                # nonlocal is py3 specific, so we just set it on the function
+                if third_time_is_the_charm.a < 2:
+                    third_time_is_the_charm.a += 1
                     raise requests.exceptions.RequestException
                 return MockResponse(json_data={"data": {}}, status_code=200)
+
+            third_time_is_the_charm.a = 0
 
             mock_post.side_effect = third_time_is_the_charm
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,21 +44,16 @@ def client():
 
 class TestClientRetries:
     @mock.patch("authalligator_client.utils.time.sleep")
-    def test_basic(self, client):
-        with mock.patch("authalligator_client.client.requests.post") as mock_post:
-
-            def third_time_is_the_charm(*args, **kwargs):
-                # nonlocal is py3 specific, so we just set it on the function
-                if third_time_is_the_charm.a < 2:
-                    third_time_is_the_charm.a += 1
-                    raise requests.exceptions.RequestException
-                return MockResponse(json_data={"data": {}}, status_code=200)
-
-            third_time_is_the_charm.a = 0
-
-            mock_post.side_effect = third_time_is_the_charm
-
-            client._make_request("", {}, dict)
+    @mock.patch(
+        "authalligator_client.client.requests.post",
+        side_effect=[
+            requests.exceptions.RequestException,
+            requests.exceptions.RequestException,
+            MockResponse(json_data={"data": {}}, status_code=200),
+        ],
+    )
+    def test_basic(self, _post, _sleep, client):
+        client._make_request("", {}, dict)
 
 
 class TestAuthorizeAccount:


### PR DESCRIPTION
This allows for more graceful handling of intermittent networking issues or when doing things like db failovers, etc.