### PR TITLE
Request `access` from `authorizeAccount` mutation

### DIFF
--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -96,6 +96,11 @@ class Client(object):
                     username
                     accessToken
                     accessTokenExpiresAt
+                    access {
+                      token
+                      scopes
+                      expiresAt
+                    }
                   }
                   accountKey
                   numberOfAccountKeys

--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -174,7 +174,7 @@ class Account(BaseAAEntity):
     )  # type: Optional[datetime.datetime]
     access = attr.attrib(
         converter=entity_converter(AccessToken)  # type: ignore[misc]
-    )  # type: Union[Omitted, List[AccessToken]]
+    )  # type: Union[Omitted, AccessToken]
 
 
 @attr.attrs(frozen=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -97,6 +97,8 @@ class TestAuthorizeAccount:
         assert account.username == "test-username"
         assert account.access_token == "access-token-example"
         assert account.access_token_expires_at == expires_at
+        assert account.access.token == "access-token-example"
+        assert account.access.expires_at == expires_at
 
     def test_authorize_account_errors(self, client):
         gql_response = {
@@ -156,6 +158,7 @@ class TestQueryAccount:
         assert account.access_token == "access-token-example"
         assert account.access_token_expires_at == expires_at
         assert account.access.token == "access-token-example"
+        assert account.access.expires_at == expires_at
 
     def test_query_account_errors(self, client):
         gql_response = {


### PR DESCRIPTION
Request `access` from `authorizeAccount` mutation as `account.accessToken` and `account.accessTokenExpiresAt` will be removed soon. 

`verifyAccount` will be removed too, that's why I'm also leaving it as-is.
