### PR TITLE
Drop `access` resolver

### DIFF
--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -153,7 +153,7 @@ class Client(object):
         """
         query = """
             query getAccount($access: AccountAccessInput!, $scopes: [String!]) {
-              account(access: $access) {
+              account(access: $access, scopes: $scopes) {
                 __typename
                 ... on Account {
                   provider

--- a/authalligator_client/client.py
+++ b/authalligator_client/client.py
@@ -96,11 +96,6 @@ class Client(object):
                     username
                     accessToken
                     accessTokenExpiresAt
-                    access {
-                      token
-                      scopes
-                      expiresAt
-                    }
                   }
                   accountKey
                   numberOfAccountKeys
@@ -165,11 +160,6 @@ class Client(object):
                   username
                   accessToken
                   accessTokenExpiresAt
-                  access(scopes: $scopes) {
-                    token
-                    scopes
-                    expiresAt
-                  }
                 }
                 ... on AccountError {
                   code

--- a/authalligator_client/entities.py
+++ b/authalligator_client/entities.py
@@ -150,19 +150,6 @@ class AccountError(BaseAAEntity):
 
 
 @attr.attrs(frozen=True)
-class AccessToken(BaseAAEntity):
-    TYPENAME = "AccessToken"
-
-    token = attr.attrib()  # type: str
-    scopes = attr.attrib(
-        converter=converters.optional(list)
-    )  # type: Optional[List[str]]
-    expires_at = attr.attrib(
-        converter=converters.optional(ciso8601.parse_datetime)
-    )  # type: Optional[datetime.datetime]
-
-
-@attr.attrs(frozen=True)
 class Account(BaseAAEntity):
     TYPENAME = "Account"
 
@@ -172,9 +159,6 @@ class Account(BaseAAEntity):
     access_token_expires_at = attr.attrib(
         converter=converters.optional(ciso8601.parse_datetime),
     )  # type: Optional[datetime.datetime]
-    access = attr.attrib(
-        converter=entity_converter(AccessToken)  # type: ignore[misc]
-    )  # type: Union[Omitted, AccessToken]
 
 
 @attr.attrs(frozen=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,11 +68,6 @@ class TestAuthorizeAccount:
                         "username": "test-username",
                         "accessToken": "access-token-example",
                         "accessTokenExpiresAt": expires_at.isoformat(),
-                        "access": {
-                            "token": "access-token-example",
-                            "scopes": ["scope1", "scope2"],
-                            "expiresAt": expires_at.isoformat(),
-                        },
                     },
                     "accountKey": "dummy-account-key",
                     "numberOfAccountKeys": 1,
@@ -97,8 +92,6 @@ class TestAuthorizeAccount:
         assert account.username == "test-username"
         assert account.access_token == "access-token-example"
         assert account.access_token_expires_at == expires_at
-        assert account.access.token == "access-token-example"
-        assert account.access.expires_at == expires_at
 
     def test_authorize_account_errors(self, client):
         gql_response = {
@@ -136,11 +129,6 @@ class TestQueryAccount:
                     "username": "test-username",
                     "accessToken": "access-token-example",
                     "accessTokenExpiresAt": expires_at.isoformat(),
-                    "access": {
-                        "token": "access-token-example",
-                        "scopes": ["scope1", "scope2"],
-                        "expiresAt": expires_at.isoformat(),
-                    },
                 }
             }
         }
@@ -157,8 +145,6 @@ class TestQueryAccount:
         assert account.username == "test-username"
         assert account.access_token == "access-token-example"
         assert account.access_token_expires_at == expires_at
-        assert account.access.token == "access-token-example"
-        assert account.access.expires_at == expires_at
 
     def test_query_account_errors(self, client):
         gql_response = {
@@ -240,11 +226,6 @@ class TestVerifyAccount:
                         "username": "test-username",
                         "accessToken": "test-access-token",
                         "accessTokenExpiresAt": expires_at.isoformat(),
-                        "access": {
-                            "token": "access-token-example",
-                            "scopes": ["scope1", "scope2"],
-                            "expiresAt": expires_at.isoformat(),
-                        },
                     },
                 }
             }
@@ -261,8 +242,6 @@ class TestVerifyAccount:
         assert isinstance(account, Account)
         assert account.provider == ProviderType.TEST
         assert account.username == "test-username"
-        assert account.access_token == "test-access-token"
-        assert account.access_token_expires_at == expires_at
 
     def test_verify_account_errors(self, client):
         gql_response = {


### PR DESCRIPTION
With the new API changes, the `accessToken` and `accessTokenExpiresAt` fields will be affected by the `scopes` parameter so the `access` field is no longer necessary.